### PR TITLE
Added support for tasks greater than 100KB in size

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 '''
 Copyright 2014 FreshPlanet (http://freshplanet.com | opensource@freshplanet.com)
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
         http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +21,6 @@ from google.appengine.api import taskqueue, modules
 from google.appengine.ext import ndb
 from google.appengine.ext.deferred import deferred
 import webapp2
-
 
 # List of task queue names we should use as default queues to execute the tasks
 DEFAULT_QUEUES = ['default']
@@ -49,14 +45,13 @@ BACKGROUND_MODULE = None
 @ndb.tasklet
 def addTask(queues, func, *args, **kwargs):
     """ Enqueue a task to execute the specified function call later from the task queue.
-    
+
     Handle exceptions and dispatching to the right queue.
-    
+
     @param queues: List of queues names. We will randomly select one to push the task into.
                     Can be 'default' to use default queues.
-    
-    @param func: The function to execute later
 
+    @param func: The function to execute later
     @param _countdown: seconds to wait before calling the function
     @param _eta: timestamp defining when to call the function
     @param _name: Name to give the Task; if not specified, a name will be
@@ -64,13 +59,17 @@ def addTask(queues, func, *args, **kwargs):
         Must match the _TASK_NAME_PATTERN regular expression: ^[a-zA-Z0-9_-]{1,500}$
     @param _target: specific version and/or module the task should execute on
     @param _raiseIfExists: if set to True, we raise the eventual TaskAlreadyExistsError
-    
+    @param _transactional: to make sure task in enqueued in the task queue
+    @param _retry_options: task queue retry options
+    @param _parent: ndb Key instance, if provided, function payload will be stored in data store entity under this
+    parent if the size of payload exceeds 100KB. Max size of payload could be 1MB otherwise data store will throw error
+
     @return: A Future that will yield True if the task could be enqueued.
     @rtype: ndb.Future
     """
     if not isinstance(queues, list):
         queues = DEFAULT_QUEUES
-    
+
     _raiseIfExists = kwargs.pop('_raiseIfExists', False)
     taskName = kwargs.pop('_name', None)
     countdown = kwargs.pop('_countdown', None)
@@ -78,7 +77,8 @@ def addTask(queues, func, *args, **kwargs):
     target = kwargs.pop('_target', None)
     transactional = kwargs.pop('_transactional', False)
     retry_options = kwargs.pop('_retry_options', None)
-    
+    parent = kwargs.pop('_parent', None)
+
     if not target and BACKGROUND_MODULE:
         # Tasks from the default module are executed into the background module.
         # Tasks from other modules (stage, background) stays inside their module.
@@ -86,12 +86,12 @@ def addTask(queues, func, *args, **kwargs):
             # Target mirror of current version to avoid compatibility issues
             # If that version does not exist, it will fall back to the default background version.
             target = modules.get_current_version_name() + '.' + BACKGROUND_MODULE
-    
+
     success = False
     try:
-        yield _defer(queues, func, args, kwargs, countdown, eta, taskName, target, transactional, retry_options)
+        yield _defer(queues, func, args, kwargs, countdown, eta, taskName, target, transactional, retry_options, parent)
         success = True
-            
+
     except (taskqueue.TaskAlreadyExistsError, taskqueue.TombstonedTaskError):
         # TaskAlreadyExistsError: a task with same name is in the queue
         # TombstonedTaskError: a task with same name has been in the queue recently
@@ -104,8 +104,50 @@ def addTask(queues, func, *args, **kwargs):
             logging.exception("Could not enqueue the task")
     except:
         logging.exception("Could not enqueue the task")
-    
+
     raise ndb.Return(success)
+
+
+class _DeferredTaskEntity(ndb.Model):
+    """Datastore representation of a deferred task.
+
+    This is used in cases when the deferred task is too big to be included as
+    payload with the task queue entry.
+    """
+    data = ndb.BlobProperty(required=True)
+
+
+def run_from_datastore(key_url_safe_id):
+    """Retrieves a task from the datastore and executes it.
+
+    Args:
+    key: The datastore key of a _DeferredTaskEntity storing the task.
+    Returns:
+    The return value of the function invocation.
+    """
+    logging.info('Retrieving function payload from data store')
+    key = ndb.Key(urlsafe=key_url_safe_id)
+    entity = key.get()
+    if not entity:
+        logging.error("Datastore entity not found for key: %s", key)
+        raise deferred.PermanentTaskFailure
+    try:
+        try:
+            func, args, kwds = cPickle.loads(entity.data)
+        except Exception:
+            logging.exception("Permanent failure attempting to execute task")
+            raise deferred.PermanentTaskFailure
+        func(*args, **kwds)
+        entity.key.delete()
+    except TypeError:
+        entity.key.delete()
+        raise TypeError
+    except deferred.SingularTaskFailure:
+        entity.key.delete()
+        raise deferred.SingularTaskFailure
+    except deferred.PermanentTaskFailure:
+        entity.key.delete()
+        raise deferred.PermanentTaskFailure
 
 
 def isFromTaskQueue(request=None):
@@ -143,11 +185,11 @@ def logAsRetried(message, *args, **kwargs):
     logging.log(level, message, *args, **kwargs)
 
 
-def _defer(queues, func, funcArgs, funcKwargs, countdown=None, eta=None, 
-           taskName=None, target=None, transactional=False, retry_options=None):
+def _defer(queues, func, funcArgs, funcKwargs, countdown=None, eta=None,
+           taskName=None, target=None, transactional=False, retry_options=None, parent=None):
     """
     Our own implementation of deferred.defer.
-    
+
     This allows:
     - using webapp2 as deferred handler and applying our middlewares
     - using task asynchronous API
@@ -155,27 +197,38 @@ def _defer(queues, func, funcArgs, funcKwargs, countdown=None, eta=None,
     - logging headers at DEBUG level instead of INFO
     """
     payload = _serialize(func, funcArgs, funcKwargs)
-    
+
     queueName = random.choice(queues)
-    
+
     # We track which function is called so that it appears clearly in the App admin dash-board.
     # Note: if it's a class method, we only track the method name and not the class name.
     url = "/_cb/deferred/%s/%s" % (getattr(func, '__module__', ''), getattr(func, '__name__', ''))
-    
+
     headers = {"Content-Type": "application/octet-stream"}
-    
-    task = taskqueue.Task(payload=payload, target=target, url=url, headers=headers,
-                          countdown=countdown, eta=eta, name=taskName, retry_options=retry_options)
-    
+
+    try:
+        task = taskqueue.Task(payload=payload, target=target, url=url, headers=headers,
+                              countdown=countdown, eta=eta, name=taskName, retry_options=retry_options)
+    except taskqueue.TaskTooLargeError:
+        logging.info('Task Too Large. Storing payload in the data store')
+        if parent:
+            # In case if data store entity needs to be stored under any specific parent
+            key = _DeferredTaskEntity(data=payload, parent=parent).put()
+        else:
+            key = _DeferredTaskEntity(data=payload).put()
+        payload = _serialize(run_from_datastore, key.urlsafe(), {})
+        task = taskqueue.Task(payload=payload, target=target, url=url, headers=headers,
+                              countdown=countdown, eta=eta, name=taskName, retry_options=retry_options)
+
     return task.add_async(queueName, transactional=transactional)
 
 
 class DeferredHandler(webapp2.RequestHandler):
-    
     # Queue & task name are already set in the request log.
     # We don't care about country and name-space.
-    _SKIP_HEADERS = {'x-appengine-country', 'x-appengine-queuename', 'x-appengine-taskname', 'x-appengine-current-namespace'}
-    
+    _SKIP_HEADERS = {'x-appengine-country', 'x-appengine-queuename', 'x-appengine-taskname',
+                     'x-appengine-current-namespace'}
+
     def post(self, *args, **kwargs):
         """ Executes a deferred task """
         # Add some task debug information.
@@ -185,11 +238,11 @@ class DeferredHandler(webapp2.RequestHandler):
             if k.startswith("x-appengine-") and k not in self._SKIP_HEADERS:
                 headers.append("%s:%s" % (key, value))
         logging.debug(", ".join(headers))
-        
+
         # Make sure all modules are loaded
         if WARMUP_MODULE:
             importlib.import_module(WARMUP_MODULE)
-        
+
         # Make sure we are called from the Task Queue (security)
         if isFromTaskQueue(self.request):
             try:
@@ -197,9 +250,12 @@ class DeferredHandler(webapp2.RequestHandler):
             except Exception:
                 logging.exception("Permanent failure attempting to execute task")
                 return
-            
+
             try:
-                func(*args, **kwds)
+                if func.__name__ == 'run_from_datastore':
+                    func(args)
+                else:
+                    func(*args, **kwds)
             except TypeError:
                 logging.debug("Deferred function arguments: %s %s", args, kwds)
                 raise
@@ -211,19 +267,20 @@ class DeferredHandler(webapp2.RequestHandler):
                 self.response.set_status(408)
             except deferred.PermanentTaskFailure:
                 logging.exception("Permanent failure attempting to execute task")
-            
+
         else:
             logging.critical('Detected an attempted XSRF attack: we are not executing from a task queue.')
             self.response.set_status(403)
 
-#===========================================================================
+
+# ===========================================================================
 # From google.appengine.ext.deferred.defer lib
-#===========================================================================
+# ===========================================================================
 
 
 def _invokeMember(obj, memberName, *args, **kwargs):
     """Retrieves a member of an object, then calls it with the provided arguments.
-    
+
     Args:
       obj: The object to operate on.
       membername: The name of the member to retrieve from ojb.
@@ -237,10 +294,10 @@ def _invokeMember(obj, memberName, *args, **kwargs):
 
 def _curry_callable(obj, args, kwargs):
     """Takes a callable and arguments and returns a task queue tuple.
-    
+
     The returned tuple consists of (callable, args, kwargs), and can be pickled
     and unpickled safely.
-    
+
     Args:
       obj: The callable to curry. See the module docstring for restrictions.
       args: Positional arguments to call the callable with.
@@ -269,7 +326,7 @@ def _curry_callable(obj, args, kwargs):
 
 def _serialize(obj, args, kwargs):
     """Serializes a callable into a format recognized by the deferred executor.
-    
+
     Args:
       obj: The callable to serialize. See module docstring for restrictions.
       args: Positional arguments to call the callable with.


### PR DESCRIPTION
The native "deferred" service provided by GAE has the functionality that if size of the task exceeds 100KB, the task payload is stored in the data store and retrieved back when required. This improved version of "deferred" service was missing this helpful functionality for long time. Last year, I added support for "_transactional" and "_retry_options" params in this version of deferred service. I am adding support for the task size now. :-)